### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD Healthcare Claims Analyzer
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/healthcare-claims-an/security/code-scanning/1](https://github.com/Fadil369/healthcare-claims-an/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/ci.yml`. This block can be added at the root level (just below the `name:` and `on:` keys), which will apply the permissions to all jobs in the workflow unless overridden at the job level. For the jobs shown, the minimal required permission is `contents: read`, as none of the jobs need to write to the repository or access other privileged resources. 

The change should be made by inserting the following block after the `name:` and before the `on:` key:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
